### PR TITLE
Improve audio fade-out and focus handling

### DIFF
--- a/app/src/main/kotlin/com/d4rk/musicsleeptimer/plus/workers/SleepAudioWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/musicsleeptimer/plus/workers/SleepAudioWorker.kt
@@ -239,15 +239,20 @@ class SleepAudioWorker(
     }
 
     private fun AudioManager.hasControllableOutputDevice(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE + 1) {
-            runCatching {
-                getSupportedDeviceTypes(AudioManager.GET_DEVICES_OUTPUTS)
-                    .any { it != AudioDeviceInfo.TYPE_UNKNOWN }
-            }.getOrDefault(false)
+        return if (Build.VERSION.SDK_INT >= 35) {
+            hasSupportedFutureOutputDevice()
         } else {
             getDevices(AudioManager.GET_DEVICES_OUTPUTS)
                 .any { it.type != AudioDeviceInfo.TYPE_UNKNOWN }
         }
+    }
+
+    @RequiresApi(35)
+    private fun AudioManager.hasSupportedFutureOutputDevice(): Boolean {
+        return runCatching {
+            getSupportedDeviceTypes(AudioManager.GET_DEVICES_OUTPUTS)
+                .any { it != AudioDeviceInfo.TYPE_UNKNOWN }
+        }.getOrDefault(false)
     }
 
     @Throws(InterruptedException::class)


### PR DESCRIPTION
## Summary
- detect controllable audio outputs and register playback callbacks before restoring volume to better respect platform capabilities
- coordinate volume fading with transient exclusive audio focus to reliably silence playback and restore user settings when playback actually stops

## Testing
- bash ./gradlew :app:lintVitalRelease *(fails: SDK location not found in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fd2a6670832da79418205a1740dc