### PR TITLE
Add media key fallback for resilient playback apps

### DIFF
--- a/app/src/main/kotlin/com/d4rk/musicsleeptimer/plus/workers/SleepAudioWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/musicsleeptimer/plus/workers/SleepAudioWorker.kt
@@ -11,6 +11,8 @@ import android.media.AudioPlaybackConfiguration
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
+import android.view.KeyEvent
 import androidx.annotation.RequiresApi
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
@@ -32,6 +34,7 @@ class SleepAudioWorker(
         private val FADE_STEP_MILLIS : Long = TimeUnit.SECONDS.toMillis(1)
         private val RESTORE_VOLUME_MILLIS : Long = TimeUnit.SECONDS.toMillis(2)
         private val WAIT_FOR_PLAYBACK_STOP_MILLIS : Long = TimeUnit.SECONDS.toMillis(4)
+        private val MEDIA_KEY_WAIT_MILLIS : Long = TimeUnit.MILLISECONDS.toMillis(500)
         private const val MAX_FADE_STEPS : Int = 20
         private const val UNIQUE_WORK_NAME : String = "sleep_audio_work"
         const val ACTION_SLEEP_AUDIO : String = "com.d4rk.musicsleeptimer.plus.action.SLEEP_AUDIO"
@@ -104,6 +107,10 @@ class SleepAudioWorker(
 
             sleepFor(RESTORE_VOLUME_MILLIS)
             playbackStopped = playbackStopped || !audioManager.isMusicActive
+
+            if (!playbackStopped) {
+                playbackStopped = audioManager.forceStopPlayback()
+            }
 
             Result.success()
         } catch (interrupted: InterruptedException) {
@@ -236,6 +243,37 @@ class SleepAudioWorker(
 
     private fun AudioManager.lowerVolumeStep() {
         adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_LOWER, 0)
+    }
+
+    private fun AudioManager.forceStopPlayback(): Boolean {
+        // Some media apps ignore transient audio focus loss. Use media key events as a
+        // last resort to request a pause/stop through the same channel as hardware keys.
+        val keyCodes = listOf(
+            KeyEvent.KEYCODE_MEDIA_PAUSE,
+            KeyEvent.KEYCODE_MEDIA_STOP,
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
+        )
+
+        for (keyCode in keyCodes) {
+            if (Thread.currentThread().isInterrupted) {
+                break
+            }
+
+            val eventTime = SystemClock.uptimeMillis()
+            val downEvent = KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN, keyCode, 0)
+            val upEvent = KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP, keyCode, 0)
+
+            runCatching { dispatchMediaKeyEvent(downEvent) }
+            runCatching { dispatchMediaKeyEvent(upEvent) }
+
+            this@SleepAudioWorker.sleepFor(MEDIA_KEY_WAIT_MILLIS)
+
+            if (!isMusicActive) {
+                return true
+            }
+        }
+
+        return !isMusicActive
     }
 
     private fun AudioManager.hasControllableOutputDevice(): Boolean {


### PR DESCRIPTION
## Summary
- add a media-key fallback in the sleep worker to pause stubborn players that ignore audio focus loss
- wait briefly after dispatching simulated pause/stop key events before rechecking playback state

## Testing
- bash gradlew lint --no-daemon --console=plain *(fails: requires local Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68e20cad2624832dbef08e573f5741cc